### PR TITLE
fix: use https for stats

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -43,4 +43,4 @@ const { title, description, image = '/placeholder-social.jpg' } = Astro.props;
 
 <!-- Stats -->
 <script data-goatcounter="https://anglepoised.goatcounter.com/count"
-        async src="//gc.zgo.at/count.js"></script>
+        async src="https://gc.zgo.at/count.js"></script>


### PR DESCRIPTION
Goatcounter-supplied code uses [protocol-relative URL][1] anti-pattern.

[1]: https://www.paulirish.com/2010/the-protocol-relative-url/
