### PR TITLE
feat: remove twitter nav link

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,7 +11,6 @@ import { SITE_TITLE } from "../config";
     <HeaderLink href="/">Home</HeaderLink>
     <HeaderLink href="/notes">Notes</HeaderLink>
     <!-- <HeaderLink href="/about">About</HeaderLink> -->
-    <HeaderLink href="https://twitter.com/anglepoised">Twitter</HeaderLink>
     <HeaderLink href="https://github.com/anglepoised">GitHub</HeaderLink>
   </nav>
 </header>


### PR DESCRIPTION
I don't habitually use Twitter so not much point linking to it.
