### PR TITLE
build: fix incorrect toml nesting

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,12 +3,13 @@
 
 [[plugins]]
 package = "@netlify/plugin-lighthouse"
+
+  [plugins.inputs]
+    output_path = "lighthouse/index.html"
+
   [plugins.inputs.thresholds]
     performance = 0.9
     accessibility = 0.9
     best-practices = 0.9
     seo = 0.9
     pwa = 0.0 # Skip PWA threshold for now
-
-  [plugins.inputs]
-    output_path = "lighthouse/index.html"


### PR DESCRIPTION
Fixes Netlify build giving this warning:

```
Incorrect TOML configuration format: Key inputs is already used as table key
```
