### PR TITLE
feat: change site name

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 // Place any global data in this file.
 // You can import this data from anywhere in your site by using the `import` keyword.
 
-export const SITE_TITLE = "Anglepoised Notes";
+export const SITE_TITLE = "anglepoised";
 export const SITE_DESCRIPTION = "Order coupled with pleasing decoration.";


### PR DESCRIPTION
Anglepoised Notes made more sense when this was on the notes.anglepoised.com subdomain.
