### PR TITLE
fix: repair feed

### DIFF
--- a/src/pages/feed/feed.xml.js
+++ b/src/pages/feed/feed.xml.js
@@ -1,10 +1,18 @@
 import rss from "@astrojs/rss";
 import { SITE_TITLE, SITE_DESCRIPTION } from "../../config";
+const postImportResult = import.meta.glob("../notes/**/*.mdx", {
+  eager: true,
+});
+const posts = Object.values(postImportResult);
 
 export const get = () =>
   rss({
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     site: import.meta.env.SITE,
-    items: import.meta.glob("../notes/**/*.md"),
+    items: posts.map((post) => ({
+      link: post.url,
+      title: post.frontmatter.title,
+      pubDate: post.frontmatter.datePublished,
+    })),
   });


### PR DESCRIPTION
Was broken in various ways:

- change from `pubDate` was not great, used internally
- change to `.mdx` broke path

Used [Astro Docs example][1] to rebuild.

[1]: https://docs.astro.build/en/guides/rss/
