### PR TITLE
feat: add sitemap redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -3,6 +3,9 @@
 /rss/	/feed/
 /feed/ /feed/feed.xml 200
 
+# sitemap redirects
+/sitemap.xml /sitemap-index.xml
+
 # v1 redirects
 /weblog/entry/000134/ /notes/small-circular-motion/
 


### PR DESCRIPTION
No longer using `/sitemap.xml`, generating `/sitemap-index.xml` instead.
