### PR TITLE
fix: feed redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,7 +1,7 @@
 # feed redirects and rewrites
-/atom.xml	/feed/
-/rss/	/feed/
-/feed/ /feed/feed.xml 200
+/atom.xml	/feed
+/rss*	/feed
+/feed* /feed/feed.xml 200
 
 # sitemap redirects
 /sitemap.xml /sitemap-index.xml


### PR DESCRIPTION
Netlify and Cloudflare pages differ in how they
handle trailing slashes.
